### PR TITLE
docs: READMEを日本語に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,57 @@
-# React + TypeScript + Vite
+# スケジュールアプリ
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React + TypeScript + Vite で構築されたPWA対応のスケジュール管理アプリです。
 
-Currently, two official plugins are available:
+## 機能
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- カレンダー表示（月表示、前月/次月ナビゲーション）
+- スケジュールのCRUD操作（作成・読取・更新・削除）
+- ローカルストレージによるデータ永続化
+- PWA対応（オフライン動作、ホーム画面に追加可能）
+- レスポンシブデザイン（iPhone対応）
 
-## React Compiler
+## 技術スタック
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+- **フレームワーク**: React 19
+- **言語**: TypeScript
+- **ビルドツール**: Vite
+- **PWA**: vite-plugin-pwa
 
-## Expanding the ESLint configuration
+## セットアップ
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+```bash
+# 依存関係のインストール
+npm install
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+# 開発サーバーの起動
+npm run dev
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
+# プロダクションビルド
+npm run build
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+# ビルド結果のプレビュー
+npm run preview
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## プロジェクト構成
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
 ```
+src/
+├── components/      # UIコンポーネント
+│   ├── Calendar.tsx
+│   ├── ScheduleForm.tsx
+│   └── ScheduleList.tsx
+├── hooks/           # カスタムフック
+│   └── useSchedules.ts
+├── types/           # 型定義
+│   └── schedule.ts
+├── utils/           # ユーティリティ関数
+│   ├── date.ts
+│   └── storage.ts
+├── App.tsx
+└── main.tsx
+```
+
+## ライセンス
+
+MIT


### PR DESCRIPTION
## Summary
- Viteデフォルトの英語READMEをプロジェクト固有の日本語READMEに変更
- 機能一覧、技術スタック、セットアップ手順、プロジェクト構成を追加

## Test plan
- [x] READMEの内容が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)