### PR TITLE
fix: 日付のタイムゾーン問題を修正

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,9 +1,13 @@
 export function formatDate(date: Date): string {
-  return date.toISOString().split('T')[0];
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 export function formatDisplayDate(dateStr: string): string {
-  const date = new Date(dateStr);
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
   return date.toLocaleDateString('ja-JP', {
     year: 'numeric',
     month: 'long',


### PR DESCRIPTION
## Summary
- 「今日」の日付が1日ずれる問題を修正

## 原因
- `toISOString()`がUTC時間を返すため、日本時間（UTC+9）とずれていた

## 修正内容
- `formatDate`: ローカル時間を使用するよう変更
- `formatDisplayDate`: 日付文字列を正しくパースするよう修正

## Test plan
- [ ] 開発環境で「今日」が正しい日付にハイライトされることを確認
- [ ] スケジュール作成時の日付が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)