### PR TITLE
fix: Vitest型定義を追加してビルドエラーを修正

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,7 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
-    "types": ["node"],
+    "types": ["node", "vitest/config"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
## Summary
- GitHub Actionsでのビルドエラーを修正

## 原因
- `tsconfig.node.json`に`vitest/config`の型定義がなかった
- `vite.config.ts`の`test`プロパティでTypeScriptエラーが発生

## 修正内容
- `tsconfig.node.json`の`types`に`vitest/config`を追加

## Test plan
- [x] `npm run build`が成功することを確認
- [x] GitHub Actionsでデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)