### PR TITLE
fix: スケジュール作成時の時刻バリデーションを追加

### DIFF
--- a/src/components/ScheduleForm.css
+++ b/src/components/ScheduleForm.css
@@ -118,6 +118,24 @@ form {
   gap: 12px;
 }
 
+.error-message {
+  color: #dc2626;
+  font-size: 0.875rem;
+  padding: 8px 12px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  margin: 8px 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.error-message::before {
+  content: '⚠';
+  font-size: 1rem;
+}
+
 .color-picker {
   display: flex;
   gap: 8px;
@@ -185,6 +203,17 @@ form {
 
 .btn-submit:active {
   background: #1d4ed8;
+}
+
+.btn-submit:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.btn-submit:disabled:active {
+  background: #9ca3af;
+  transform: none;
 }
 
 /* デスクトップ向け: 中央モーダル表示 */


### PR DESCRIPTION
## 概要
スケジュール作成時に開始時刻が終了時刻よりも後になる設定を防ぐバリデーションを追加しました。

Closes #16

## 変更内容
- 開始時刻と終了時刻を比較するバリデーション関数 `validateTime` を追加
- 時刻フィールドの変更時にリアルタイムでバリデーションを実行
- バリデーションエラー時にエラーメッセージを表示
- エラーがある場合は送信ボタンを無効化
- エラーメッセージ用のCSSスタイル（`.error-message`, `.btn-submit:disabled`）を追加

## 修正したバグ
開始時刻が終了時刻よりも後の時刻を設定できてしまい、不正なデータがLocalStorageに保存されていた問題を修正しました。

## テスト方法
1. スケジュール作成画面を開く
2. 開始時刻に「14:00」を入力
3. 終了時刻に「12:00」を入力
4. エラーメッセージ「開始時刻は終了時刻よりも前に設定してください」が表示されることを確認
5. 送信ボタンが無効化されていることを確認
6. 終了時刻を「15:00」に変更
7. エラーメッセージが消え、送信ボタンが有効化されることを確認
8. 正常に保存できることを確認

## スクリーンショット
（必要に応じて追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)