### PR TITLE
Revert "レイアウトの改善: ヘッダーの高さを削減し、スケジュールリストのスクロール動作を最適化"

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,8 +8,8 @@
 .app-header {
   background: #3b82f6;
   color: white;
-  padding: 8px 20px;
-  padding-top: calc(8px + var(--safe-area-top, 0px));
+  padding: 16px 20px;
+  padding-top: calc(16px + var(--safe-area-top, 0px));
   padding-left: calc(20px + var(--safe-area-left, 0px));
   padding-right: calc(20px + var(--safe-area-right, 0px));
   flex-shrink: 0;
@@ -25,9 +25,9 @@
 
 .app-main {
   flex: 1;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
   padding: 16px;
   padding-left: calc(16px + var(--safe-area-left, 0px));
   padding-right: calc(16px + var(--safe-area-right, 0px));
@@ -36,6 +36,8 @@
 
 .app-main > * {
   max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .fab {
@@ -78,8 +80,8 @@
 
 @media (max-width: 480px) {
   .app-header {
-    padding: 7px 16px;
-    padding-top: calc(7px + var(--safe-area-top, 0px));
+    padding: 14px 16px;
+    padding-top: calc(14px + var(--safe-area-top, 0px));
     padding-left: calc(16px + var(--safe-area-left, 0px));
     padding-right: calc(16px + var(--safe-area-right, 0px));
   }
@@ -113,6 +115,6 @@
 /* iOS スタンドアロンモード */
 @media (display-mode: standalone) {
   .app-header {
-    padding-top: calc(8px + var(--safe-area-top, 0px));
+    padding-top: calc(16px + var(--safe-area-top, 0px));
   }
 }

--- a/src/components/ScheduleList.css
+++ b/src/components/ScheduleList.css
@@ -4,11 +4,6 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   padding: 16px;
   margin-bottom: 16px;
-  flex: 1;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
-  max-height: 100%;
 }
 
 .list-title {


### PR DESCRIPTION
## 概要
PR #24のレイアウト改善の変更を差し戻します。

## 変更内容
以下の変更を元の状態に戻しました：

### 1. ヘッダーの高さを元に戻す
- 通常: `8px` → `16px`
- モバイル: `7px` → `14px`
- スタンドアロンモード: `8px` → `16px`

### 2. app-mainのスクロール設定を元に戻す
- `overflow: hidden` → `overflow-y: auto`
- `display: flex` と `flex-direction: column` を削除

### 3. ScheduleListのスクロール設定を削除
- `flex: 1`、`overflow-y: auto`、`-webkit-overflow-scrolling: touch`、`overscroll-behavior: contain`、`max-height: 100%` を削除

## 理由
ユーザーの要望により、レイアウト改善の変更を差し戻します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)