### PR TITLE
レイアウトとスクロール動作の改善、開発サーバー設定の追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,9 +3,14 @@
   display: flex;
   flex-direction: column;
   background: #f3f4f6;
+  overflow: hidden;
 }
 
 .app-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   background: #3b82f6;
   color: white;
   padding: 16px 20px;
@@ -25,19 +30,21 @@
 
 .app-main {
   flex: 1;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
+  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
   padding: 16px;
+  margin-top: calc(57px + var(--safe-area-top, 0px));
   padding-left: calc(16px + var(--safe-area-left, 0px));
   padding-right: calc(16px + var(--safe-area-right, 0px));
-  padding-bottom: calc(100px + var(--safe-area-bottom, 0px));
+  padding-bottom: calc(16px + var(--safe-area-bottom, 0px));
 }
 
 .app-main > * {
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
+  width: 100%;
 }
 
 .fab {
@@ -92,9 +99,10 @@
 
   .app-main {
     padding: 12px;
+    margin-top: calc(53px + var(--safe-area-top, 0px));
     padding-left: calc(12px + var(--safe-area-left, 0px));
     padding-right: calc(12px + var(--safe-area-right, 0px));
-    padding-bottom: calc(100px + var(--safe-area-bottom, 0px));
+    padding-bottom: calc(12px + var(--safe-area-bottom, 0px));
   }
 
   .fab {
@@ -108,7 +116,8 @@
 @media (min-width: 768px) {
   .app-main {
     padding: 24px;
-    padding-bottom: calc(100px + var(--safe-area-bottom, 0px));
+    margin-top: calc(57px + var(--safe-area-top, 0px));
+    padding-bottom: calc(24px + var(--safe-area-bottom, 0px));
   }
 }
 

--- a/src/components/ScheduleList.css
+++ b/src/components/ScheduleList.css
@@ -4,6 +4,10 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   padding: 16px;
   margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
 }
 
 .list-title {
@@ -13,6 +17,7 @@
   margin-bottom: 16px;
   padding-bottom: 8px;
   border-bottom: 1px solid #e5e7eb;
+  flex-shrink: 0;
 }
 
 .no-schedules {
@@ -22,9 +27,13 @@
 }
 
 .schedules {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   list-style: none;
   padding: 0;
   margin: 0;
+  min-height: 0;
 }
 
 .schedule-item {

--- a/src/components/ScheduleList.tsx
+++ b/src/components/ScheduleList.tsx
@@ -1,5 +1,4 @@
 import type { Schedule } from '../types/schedule';
-import { formatDisplayDate } from '../utils/date';
 import './ScheduleList.css';
 
 interface ScheduleListProps {
@@ -17,8 +16,6 @@ export function ScheduleList({ schedules, selectedDate, onEdit, onDelete }: Sche
 
   return (
     <div className="schedule-list">
-      <h3 className="list-title">{formatDisplayDate(selectedDate)}</h3>
-
       {filteredSchedules.length === 0 ? (
         <p className="no-schedules">予定がありません</p>
       ) : (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,13 @@ import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
+  server: {
+    host: true,
+    port: 5173,
+    allowedHosts: ['.ngrok-free.dev', 'localhost'], // すべてのホストを許可
+    // または特定のホストのみ許可する場合
+    // allowedHosts: ['.ngrok-free.app', 'localhost']
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- ヘッダーを固定位置に変更してスクロール時も表示を維持
- スクロール領域をScheduleListコンポーネント内に限定し、カレンダーとリストが独立してスクロール可能に
- ScheduleListから日付タイトル表示を削除（カレンダーで日付選択が明確なため）
- Vite開発サーバーにngrok対応のホスト設定を追加（外部アクセステスト用）

## 変更内容
### UI/UXの改善
- **App.css**: ヘッダーを`position: fixed`に変更し、メインコンテンツにマージンを追加
- **ScheduleList.css**: flexboxレイアウトを追加し、スケジュールリストのみがスクロール可能に
- **ScheduleList.tsx**: 冗長な日付タイトルを削除

### 開発環境の改善
- **vite.config.ts**: ngrok等を使った外部アクセステスト用のサーバー設定を追加

## Test plan
- [ ] ヘッダーが固定表示されることを確認
- [ ] スケジュールリストのスクロールが正常に動作することを確認
- [ ] カレンダーとリストが独立してスクロール可能なことを確認
- [ ] 日付タイトルが削除されても使いやすさに問題がないことを確認
- [ ] 開発サーバーがngrok経由でアクセス可能なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)