### PR TITLE
docs: Safari/iPhone対応の必須ガイドラインを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,15 @@
 - React + TypeScript + Vite
 - GitHub Pagesでホスティング
 
+## 対象環境（必須）
+
+**Safari + iPhone環境で動作することを前提に設計すること。**
+
+- Safari非対応のHTML/CSS/JS機能は使用しない
+- 実装前にSafari/iOS Safariの互換性を確認する
+- 例: `<input type="time" step="...">` はSafari非対応のため`<select>`を使用する
+- iOS固有のUI/UX（セーフエリア、タッチ操作等）を考慮する
+
 ## 開発コマンド
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "vitest": "^4.0.16"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,css,md}": [
+    "*.{js,jsx,ts,tsx,json,css}": [
       "biome check --write"
     ]
   }


### PR DESCRIPTION
## Summary
- CLAUDE.mdにSafari + iPhone環境を対象環境として明記
- Safari非対応機能の使用禁止ルールを追加
- lint-stagedからmdファイルを除外（biome非対応のため）

## Test plan
- [x] CLAUDE.mdの内容が正しく表示されることを確認
- [x] lint-stagedがmdファイルを除外することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)