### PR TITLE
feat: Playwrightを使用したE2Eテストの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ dist-ssr
 # Environment variables
 .env
 .env.local
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,46 @@ npm run build
 npm run preview
 ```
 
+## テスト
+
+### ユニットテスト（Vitest）
+
+```bash
+# テストを実行（ウォッチモード）
+npm test
+
+# テストを一度だけ実行
+npm run test:run
+```
+
+### E2Eテスト（Playwright）
+
+初回のみ、Playwrightのブラウザをインストールする必要があります：
+
+```bash
+# Playwrightのブラウザをインストール
+npm run playwright:install
+```
+
+テストの実行：
+
+```bash
+# E2Eテストを実行（ヘッドレスモード）
+npm run test:e2e
+
+# E2Eテストを実行（UIモード - テスト結果を視覚的に確認）
+npm run test:e2e:ui
+
+# E2Eテストを実行（ヘッドモード - ブラウザを表示）
+npm run test:e2e:headed
+
+# E2Eテストをデバッグモードで実行
+npm run test:e2e:debug
+```
+
+E2Eテストは以下のブラウザで実行されます：
+- Mobile Safari（iPhone 14 Pro）のみ
+
 ## プロジェクト構成
 
 ```

--- a/e2e/schedule-app.spec.ts
+++ b/e2e/schedule-app.spec.ts
@@ -1,0 +1,420 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('スケジュールアプリ', () => {
+  test.beforeEach(async ({ page }) => {
+    // ローカルストレージをクリア
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+  });
+
+  test('アプリが正しく表示される', async ({ page }) => {
+    // ヘッダーが表示されている
+    await expect(page.getByRole('heading', { name: 'スケジュール' })).toBeVisible();
+
+    // カレンダーが表示されている
+    await expect(page.locator('.calendar')).toBeVisible();
+
+    // FABボタン（予定追加ボタン）が表示されている
+    await expect(page.getByRole('button', { name: '予定を追加' })).toBeVisible();
+  });
+
+  test('スケジュールを追加できる', async ({ page }) => {
+    // FABボタンをクリック
+    await page.getByRole('button', { name: '予定を追加' }).click();
+
+    // フォームが表示される（モーダルのヘッダーで確認）
+    await expect(page.getByRole('heading', { name: '新しい予定' })).toBeVisible();
+
+    // フォームに入力
+    await page.getByLabel('タイトル *').fill('テストスケジュール');
+
+    // 開始時間と終了時間を選択
+    await page.getByLabel('開始時刻').selectOption('10:00');
+    await page.getByLabel('終了時刻').selectOption('11:30');
+
+    // 説明を入力（オプション）
+    await page.getByLabel('説明').fill('これはテストのメモです');
+
+    // エラーメッセージがないことを確認
+    await expect(page.locator('.error-message')).not.toBeVisible();
+
+    // 追加ボタンが有効であることを確認してからクリック
+    const addButton = page.locator('.modal-content .btn-submit');
+    await expect(addButton).toBeEnabled();
+    await expect(addButton).toHaveText('追加');
+    await addButton.click();
+
+    // フォームが閉じる
+    await expect(page.getByRole('heading', { name: '新しい予定' })).not.toBeVisible();
+
+    // 追加したスケジュールが表示される（スケジュールリスト内で確認）
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: 'テストスケジュール' })
+    ).toBeVisible();
+
+    // 時刻も表示されることを確認
+    await expect(
+      page.locator('.schedule-item', { hasText: 'テストスケジュール' }).locator('.schedule-time')
+    ).toContainText('10:00 - 11:30');
+  });
+
+  test('スケジュールを編集できる', async ({ page }) => {
+    // まずスケジュールを追加
+    await page.getByRole('button', { name: '予定を追加' }).click();
+    await page.getByLabel('タイトル *').fill('編集前のタイトル');
+    await page.getByLabel('開始時刻').selectOption('09:00');
+    await page.getByLabel('終了時刻').selectOption('10:00');
+    await page.locator('.modal-content .btn-submit').click();
+
+    // スケジュールが表示されるまで待つ
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '編集前のタイトル' })
+    ).toBeVisible();
+
+    // 編集ボタンをクリック
+    const scheduleItem = page.locator('.schedule-item', { hasText: '編集前のタイトル' });
+    await scheduleItem.getByRole('button', { name: '編集' }).click();
+
+    // フォームが表示される（編集モードのヘッダーで確認）
+    await expect(page.getByRole('heading', { name: '予定を編集' })).toBeVisible();
+
+    // タイトルを編集
+    const titleInput = page.getByLabel('タイトル *');
+    await titleInput.clear();
+    await titleInput.fill('編集後のタイトル');
+
+    // 更新ボタンをクリック
+    await page.locator('.modal-content .btn-submit').click();
+
+    // 編集後のタイトルが表示される
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '編集後のタイトル' })
+    ).toBeVisible();
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '編集前のタイトル' })
+    ).not.toBeVisible();
+  });
+
+  test('スケジュールを削除できる', async ({ page }) => {
+    // まずスケジュールを追加
+    await page.getByRole('button', { name: '予定を追加' }).click();
+    await page.getByLabel('タイトル *').fill('削除するスケジュール');
+    await page.getByLabel('開始時刻').selectOption('14:00');
+    await page.getByLabel('終了時刻').selectOption('15:00');
+    await page.locator('.modal-content .btn-submit').click();
+
+    // スケジュールが表示されるまで待つ
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '削除するスケジュール' })
+    ).toBeVisible();
+
+    // 削除の確認ダイアログのハンドラを設定
+    page.on('dialog', async dialog => {
+      expect(dialog.message()).toContain('削除');
+      await dialog.accept();
+    });
+
+    // 削除ボタンをクリック
+    const scheduleItem = page.locator('.schedule-item', { hasText: '削除するスケジュール' });
+    await scheduleItem.getByRole('button', { name: '削除' }).click();
+
+    // スケジュールが削除されている
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '削除するスケジュール' })
+    ).not.toBeVisible();
+  });
+
+  test('カレンダーで日付を選択できる', async ({ page }) => {
+    // カレンダーの日付をクリック
+    const calendar = page.locator('.calendar');
+    await expect(calendar).toBeVisible();
+
+    // 今日の日付以外の日付をクリック
+    const dateButtons = calendar
+      .locator('button.calendar-day:not(.today):not(.other-month)')
+      .first();
+    await dateButtons.click();
+
+    // 日付が選択された状態になる（selectedクラスが付く）
+    await expect(dateButtons).toHaveClass(/selected/);
+  });
+
+  test('複数のスケジュールを追加して表示できる', async ({ page }) => {
+    // 1つ目のスケジュールを追加
+    await page.getByRole('button', { name: '予定を追加' }).click();
+    await page.getByLabel('タイトル *').fill('朝の会議');
+    await page.getByLabel('開始時刻').selectOption('09:00');
+    await page.getByLabel('終了時刻').selectOption('10:00');
+    await page.locator('.modal-content .btn-submit').click();
+
+    // 1つ目のスケジュールが表示されるまで待つ
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '朝の会議' })
+    ).toBeVisible();
+
+    // 2つ目のスケジュールを追加
+    await page.getByRole('button', { name: '予定を追加' }).click();
+    await page.getByLabel('タイトル *').fill('ランチ');
+    await page.getByLabel('開始時刻').selectOption('12:00');
+    await page.getByLabel('終了時刻').selectOption('13:00');
+    await page.locator('.modal-content .btn-submit').click();
+
+    // 両方のスケジュールが表示される
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '朝の会議' })
+    ).toBeVisible();
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: 'ランチ' })
+    ).toBeVisible();
+
+    // スケジュールが時刻順にソートされていることを確認
+    const scheduleTitles = await page.locator('.schedule-item .schedule-title').allTextContents();
+    expect(scheduleTitles).toEqual(['朝の会議', 'ランチ']);
+  });
+
+  test('フォームをキャンセルできる', async ({ page }) => {
+    // FABボタンをクリック
+    await page.getByRole('button', { name: '予定を追加' }).click();
+
+    // フォームが表示される
+    await expect(page.getByRole('heading', { name: '新しい予定' })).toBeVisible();
+
+    // フォームに入力
+    await page.getByLabel('タイトル *').fill('キャンセルするスケジュール');
+
+    // キャンセルボタンをクリック
+    await page.getByRole('button', { name: 'キャンセル' }).click();
+
+    // フォームが閉じる
+    await expect(page.getByRole('heading', { name: '新しい予定' })).not.toBeVisible();
+
+    // スケジュールは追加されていない（「予定がありません」が表示される）
+    await expect(page.getByText('予定がありません')).toBeVisible();
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: 'キャンセルするスケジュール' })
+    ).not.toBeVisible();
+  });
+});
+
+test.describe('スケジュールアプリ - 異常系', () => {
+  test.beforeEach(async ({ page }) => {
+    // ローカルストレージをクリア
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+  });
+
+  test('開始時刻が終了時刻より後の場合、エラーメッセージが表示される', async ({ page }) => {
+    // FABボタンをクリック
+    await page.getByRole('button', { name: '予定を追加' }).click();
+
+    // フォームが表示される
+    await expect(page.getByRole('heading', { name: '新しい予定' })).toBeVisible();
+
+    // タイトルを入力
+    await page.getByLabel('タイトル *').fill('時刻エラーのテスト');
+
+    // 開始時刻を終了時刻より後に設定
+    await page.getByLabel('開始時刻').selectOption('14:00');
+    await page.getByLabel('終了時刻').selectOption('13:00');
+
+    // エラーメッセージが表示される
+    await expect(page.locator('.error-message')).toBeVisible();
+    await expect(page.locator('.error-message')).toContainText(
+      '開始時刻は終了時刻よりも前に設定してください'
+    );
+
+    // 送信ボタンがdisabledになる
+    const submitButton = page.locator('.modal-content .btn-submit');
+    await expect(submitButton).toBeDisabled();
+
+    // 正しい時刻に修正するとエラーが消える
+    await page.getByLabel('終了時刻').selectOption('15:00');
+    await expect(page.locator('.error-message')).not.toBeVisible();
+    await expect(submitButton).toBeEnabled();
+  });
+
+  test('開始時刻と終了時刻が同じ場合、エラーメッセージが表示される', async ({ page }) => {
+    // FABボタンをクリック
+    await page.getByRole('button', { name: '予定を追加' }).click();
+
+    // タイトルを入力
+    await page.getByLabel('タイトル *').fill('同じ時刻のテスト');
+
+    // 開始時刻と終了時刻を同じに設定
+    await page.getByLabel('開始時刻').selectOption('10:00');
+    await page.getByLabel('終了時刻').selectOption('10:00');
+
+    // エラーメッセージが表示される
+    await expect(page.locator('.error-message')).toBeVisible();
+    await expect(page.locator('.error-message')).toContainText(
+      '開始時刻は終了時刻よりも前に設定してください'
+    );
+
+    // 送信ボタンがdisabledになる
+    await expect(page.locator('.modal-content .btn-submit')).toBeDisabled();
+  });
+
+  test('タイトルが空白文字のみの場合、送信できない', async ({ page }) => {
+    // FABボタンをクリック
+    await page.getByRole('button', { name: '予定を追加' }).click();
+
+    // タイトルに空白のみを入力
+    await page.getByLabel('タイトル *').fill('   ');
+
+    // 時刻を設定
+    await page.getByLabel('開始時刻').selectOption('10:00');
+    await page.getByLabel('終了時刻').selectOption('11:00');
+
+    // 送信ボタンをクリック
+    await page.locator('.modal-content .btn-submit').click();
+
+    // フォームが閉じない（送信が実行されない）
+    await expect(page.getByRole('heading', { name: '新しい予定' })).toBeVisible();
+
+    // スケジュールは追加されていない
+    await page.getByRole('button', { name: 'キャンセル' }).click();
+    await expect(page.getByText('予定がありません')).toBeVisible();
+  });
+
+  test('削除確認ダイアログでキャンセルすると、スケジュールが削除されない', async ({ page }) => {
+    // まずスケジュールを追加
+    await page.getByRole('button', { name: '予定を追加' }).click();
+    await page.getByLabel('タイトル *').fill('削除キャンセルのテスト');
+    await page.getByLabel('開始時刻').selectOption('10:00');
+    await page.getByLabel('終了時刻').selectOption('11:00');
+    await page.locator('.modal-content .btn-submit').click();
+
+    // スケジュールが表示されるまで待つ
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '削除キャンセルのテスト' })
+    ).toBeVisible();
+
+    // 削除確認ダイアログでキャンセルを選択
+    page.on('dialog', async dialog => {
+      expect(dialog.message()).toContain('削除');
+      await dialog.dismiss(); // キャンセルを選択
+    });
+
+    // 削除ボタンをクリック
+    const scheduleItem = page.locator('.schedule-item', { hasText: '削除キャンセルのテスト' });
+    await scheduleItem.getByRole('button', { name: '削除' }).click();
+
+    // スケジュールが削除されず、まだ表示されている
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '削除キャンセルのテスト' })
+    ).toBeVisible();
+  });
+
+  test('編集中にキャンセルすると、変更が保存されない', async ({ page }) => {
+    // まずスケジュールを追加
+    await page.getByRole('button', { name: '予定を追加' }).click();
+    await page.getByLabel('タイトル *').fill('元のタイトル');
+    await page.getByLabel('開始時刻').selectOption('10:00');
+    await page.getByLabel('終了時刻').selectOption('11:00');
+    await page.locator('.modal-content .btn-submit').click();
+
+    // スケジュールが表示されるまで待つ
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '元のタイトル' })
+    ).toBeVisible();
+
+    // 編集ボタンをクリック
+    const scheduleItem = page.locator('.schedule-item', { hasText: '元のタイトル' });
+    await scheduleItem.getByRole('button', { name: '編集' }).click();
+
+    // 編集フォームが表示される
+    await expect(page.getByRole('heading', { name: '予定を編集' })).toBeVisible();
+
+    // タイトルを変更
+    const titleInput = page.getByLabel('タイトル *');
+    await titleInput.clear();
+    await titleInput.fill('変更後のタイトル');
+
+    // キャンセルボタンをクリック
+    await page.getByRole('button', { name: 'キャンセル' }).click();
+
+    // フォームが閉じる
+    await expect(page.getByRole('heading', { name: '予定を編集' })).not.toBeVisible();
+
+    // 元のタイトルがそのまま表示されている
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '元のタイトル' })
+    ).toBeVisible();
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '変更後のタイトル' })
+    ).not.toBeVisible();
+  });
+
+  test('モーダル外をクリックすると、フォームが閉じる', async ({ page }) => {
+    // FABボタンをクリック
+    await page.getByRole('button', { name: '予定を追加' }).click();
+
+    // フォームが表示される
+    await expect(page.getByRole('heading', { name: '新しい予定' })).toBeVisible();
+
+    // タイトルを入力
+    await page.getByLabel('タイトル *').fill('モーダル外クリックのテスト');
+
+    // モーダルの外側（オーバーレイ）をクリック
+    await page.locator('.modal-overlay').click({ position: { x: 10, y: 10 } });
+
+    // フォームが閉じる
+    await expect(page.getByRole('heading', { name: '新しい予定' })).not.toBeVisible();
+
+    // スケジュールは追加されていない
+    await expect(page.getByText('予定がありません')).toBeVisible();
+  });
+
+  test('非常に長いタイトルでもスケジュールを追加できる', async ({ page }) => {
+    // 1000文字のタイトルを生成
+    const longTitle = 'あ'.repeat(1000);
+
+    // FABボタンをクリック
+    await page.getByRole('button', { name: '予定を追加' }).click();
+
+    // 長いタイトルを入力
+    await page.getByLabel('タイトル *').fill(longTitle);
+
+    // 時刻を設定
+    await page.getByLabel('開始時刻').selectOption('10:00');
+    await page.getByLabel('終了時刻').selectOption('11:00');
+
+    // 送信ボタンをクリック
+    await page.locator('.modal-content .btn-submit').click();
+
+    // フォームが閉じる
+    await expect(page.getByRole('heading', { name: '新しい予定' })).not.toBeVisible();
+
+    // スケジュールが追加される（最初の一部が表示されることを確認）
+    await expect(page.locator('.schedule-item .schedule-title').first()).toContainText('あああ');
+  });
+
+  test('非常に長い説明文でもスケジュールを追加できる', async ({ page }) => {
+    // 5000文字の説明を生成
+    const longDescription = 'これはテストです。'.repeat(500);
+
+    // FABボタンをクリック
+    await page.getByRole('button', { name: '予定を追加' }).click();
+
+    // タイトルと説明を入力
+    await page.getByLabel('タイトル *').fill('長い説明のテスト');
+    await page.getByLabel('説明').fill(longDescription);
+
+    // 時刻を設定
+    await page.getByLabel('開始時刻').selectOption('10:00');
+    await page.getByLabel('終了時刻').selectOption('11:00');
+
+    // 送信ボタンをクリック
+    await page.locator('.modal-content .btn-submit').click();
+
+    // フォームが閉じる
+    await expect(page.getByRole('heading', { name: '新しい予定' })).not.toBeVisible();
+
+    // スケジュールが追加される
+    await expect(
+      page.locator('.schedule-item .schedule-title', { hasText: '長い説明のテスト' })
+    ).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.11",
+        "@playwright/test": "^1.57.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@types/node": "^24.10.1",
@@ -3016,6 +3017,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -6630,6 +6647,53 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8996,7 +9060,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug",
+    "playwright:install": "playwright install",
     "prepare": "husky"
   },
   "dependencies": {
@@ -21,6 +26,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",
+    "@playwright/test": "^1.57.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@types/node": "^24.10.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright設定
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    // Mobile Safariのみでテスト
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 14 Pro'] },
+    },
+  ],
+
+  // 開発サーバーを自動起動
+  webServer: {
+    command: 'npm run preview',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## 変更内容

このPRは、Playwrightを使用した包括的なE2Eテストスイートを追加します。

### 追加された機能
- Playwrightのインストールと設定（v1.57.0）
- `playwright.config.ts`の作成（Mobile Safari iPhone 14 Pro対応）
- 正常系テスト7ケースの実装
  - アプリの表示確認
  - スケジュールの追加
  - スケジュールの編集
  - スケジュールの削除
  - カレンダーでの日付選択
  - 複数のスケジュール追加と表示
  - フォームのキャンセル
- 異常系テスト8ケースの実装
  - 時刻バリデーション（開始時刻 > 終了時刻）
  - 時刻バリデーション（開始時刻 = 終了時刻）
  - 空白文字のみのタイトル送信防止
  - 削除確認ダイアログでのキャンセル
  - 編集中のキャンセル
  - モーダル外クリックでの閉じる動作
  - 境界値テスト（1000文字のタイトル）
  - 境界値テスト（5000文字の説明文）

### 設定ファイルの変更
- `package.json`: Playwrightの依存関係と実行スクリプトを追加
- `.gitignore`: Playwright生成ファイルを除外
- `README.md`: E2Eテストの実行方法を追記

## テストプラン

- [x] `npm run playwright:install` でブラウザをインストール
- [x] `npm run test:e2e` でE2Eテストを実行し、全テストが成功することを確認
- [x] Mobile Safari（iPhone 14 Pro）で正常に動作することを確認
- [x] 正常系7ケース、異常系8ケースの合計15テストが全て通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)