### PR TITLE
feat: PR作成時にe2eテストを自動実行するGitHub Actionsを追加

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,57 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Build application
+        run: npm run build
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            test-results/
+          retention-days: 7
+
+      - name: Check test results
+        if: failure()
+        run: echo "E2E tests failed. Please fix the failing tests before merging."


### PR DESCRIPTION
## 概要
Issue #10 の要件に基づき、PR作成時にPlaywright e2eテストを自動実行するGitHub Actionsワークフローを追加しました。

## 変更内容

### 追加ファイル
- `.github/workflows/e2e-test.yml`

### 実装内容
- **トリガー**: PRの作成・更新時、およびmasterブランチへのpush時
- **テスト環境**: Ubuntu latest、Node.js 20
- **テスト対象**: Mobile Safari（iPhone 14 Pro）
- **タイムアウト**: 15分
- **アーティファクト保存**:
  - テストレポート（常に保存、7日間保持）
  - テスト失敗時のスクリーンショット・トレース（7日間保持）

### 既存のe2eテストでカバーされる主要フロー
- ✅ スケジュール作成（schedule-app.spec.ts）
- ✅ スケジュール編集（schedule-app.spec.ts）
- ✅ スケジュール削除（schedule-app.spec.ts）
- ✅ カレンダー表示（calendar-integration.spec.ts）
- ✅ モバイルUI操作（mobile.spec.ts）
- ✅ データ永続化（persistence.spec.ts）
- ✅ 複雑なワークフロー（complex-workflows.spec.ts）
- ✅ アクセシビリティ（accessibility.spec.ts）

## テスト計画

このPRをマージすることで、以下が自動化されます：
1. PR作成時にe2eテストが自動実行される
2. テスト失敗時はアーティファクト（レポート、スクリーンショット）が保存される
3. テスト結果がPRのチェック項目として表示される

## 次のステップ（オプション）

テスト失敗時のPRマージブロックを有効にするには、GitHubリポジトリの設定で以下を行う必要があります：

1. Settings > Branches > Branch protection rules
2. masterブランチのルールを編集
3. "Require status checks to pass before merging"を有効化
4. "E2E Tests / e2e"を必須チェックに追加

## 関連Issue
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)