### PR TITLE
git worktreeベースのワークフローを導入

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,17 +1,19 @@
 # Git Workflow Rules
 
-## Branch and Pull Request Workflow
+## Git Worktree Workflow（必須）
 
-### Always Work on New Branches
+### Always Use Git Worktree
 
-すべての変更（機能追加、バグ修正、ドキュメント変更など）は新しいブランチで作業すること。
+**すべての変更は`git worktree`を使用して新しいブランチで作業すること。**
+
+- 必ず`npm run worktree:new`コマンドを使用
 
 ### One Branch, One Change Principle
 
-**各修正は必ず別のブランチで作業する。**
+**各修正は必ず別のworktreeで作業する。**
 
 - ❌ **禁止**: 既存のブランチに別の修正を追加
-- ✅ **必須**: 新しい修正は最新のベースブランチから新しいブランチを作成
+- ✅ **必須**: 新しい修正は最新のベースブランチから新しいworktreeを作成
 
 ### All Changes via Pull Requests
 
@@ -26,33 +28,101 @@
 ### 新機能追加の場合
 
 ```bash
-# 1. ベースブランチから新しいブランチを作成
-git checkout master
-git pull origin master
-git checkout -b feat/new-feature
+# 1. 新しいworktreeを作成（依存関係も自動インストール）
+npm run worktree:new feat new-feature
 
-# 2. 変更を実装
+# 2. worktreeディレクトリに移動
+cd ../schedule-app-feat-new-feature
 
-# 3. コミット
+# 3. 開発サーバーを起動して変更を実装
+npm run dev
+
+# 4. コミット
 git add .
 git commit -m "feat: 新機能の説明"
 
-# 4. プッシュしてPR作成
+# 5. プッシュしてPR作成
 git push -u origin feat/new-feature
 # GitHub上でPRを作成
+
+# 6. 作業完了後、メインプロジェクトに戻ってworktreeを削除
+cd ../schedule-app
+npm run worktree:remove feat new-feature
 ```
 
 ### 別の修正が必要になった場合
 
 ```bash
-# ❌ 間違った方法: 既存のブランチで作業
-git checkout feat/new-feature  # これはダメ！
+# ❌ 間違った方法: 既存のworktreeで別の作業
+cd ../schedule-app-feat-new-feature  # これはダメ！
 
-# ✅ 正しい方法: 新しいブランチを作成
-git checkout master
-git pull origin master
-git checkout -b fix/another-issue
+# ✅ 正しい方法: メインプロジェクトから新しいworktreeを作成
+cd ../schedule-app
+npm run worktree:new fix another-issue  # 依存関係も自動インストール
+cd ../schedule-app-fix-another-issue
 ```
+
+### 複数ブランチの並行作業
+
+worktreeの最大のメリットは、複数のブランチを同時に作業できること：
+
+```bash
+# 機能開発用のworktree（開発サーバー起動）
+cd ../schedule-app-feat-new-feature
+npm run dev  # ポート5173で起動
+
+# 別ターミナルで緊急バグ修正（依存関係も自動インストール）
+cd ../schedule-app
+npm run worktree:new fix urgent-bug
+cd ../schedule-app-fix-urgent-bug
+# 修正してコミット
+
+# 開発サーバーはそのまま起動し続けている！
+```
+
+## Worktree Management
+
+### worktree一覧の確認
+
+```bash
+npm run worktree:list
+```
+
+### worktreeの削除
+
+作業完了後は必ずworktreeを削除してクリーンアップ：
+
+```bash
+# メインプロジェクトから実行
+cd ../schedule-app
+npm run worktree:remove feat new-feature
+```
+
+### 環境設定ファイルの自動コピー
+
+`npm run worktree:new`を実行すると、以下のファイルが自動的にコピーされます：
+
+- `.env` - 環境変数設定（存在する場合）
+- `.env.local` - ローカル環境変数設定（存在する場合）
+- `.mcp.json` - MCP（Model Context Protocol）サーバー設定
+- `.claude/settings.local.json` - Claude Codeのローカル設定（権限・フック）
+
+追加でコピーしたいファイルがある場合は `scripts/new-worktree.sh` の `FILES_TO_COPY` 配列を編集してください。
+
+### 注意事項
+
+1. **node_modulesは共有しない**
+   - worktree作成時に`npm install`が自動実行されます
+   - worktreeごとに独立した依存関係を持つため、互いに影響しません
+   - 依存関係を更新した場合は、各worktreeで再度`npm install`を実行してください
+
+2. **worktreeディレクトリの場所**
+   - 親ディレクトリに作成されます（例: `../schedule-app-feat-new-feature/`）
+   - `.gitignore`の影響を受けません
+
+3. **作業完了後のクリーンアップ**
+   - worktreeを削除してもブランチは残ります
+   - ブランチも削除する場合は`git branch -D <branch-name>`を実行
 
 ## Best Practices
 
@@ -60,6 +130,7 @@ git checkout -b fix/another-issue
 2. **明確なコミットメッセージ**: 何を変更したか明確に記述
 3. **テスト実行**: PRを作成する前に必ずテストを実行
 4. **競合の解決**: PRマージ前にベースブランチの最新変更を取り込む
+5. **worktreeのクリーンアップ**: 作業完了後は必ず`worktree:remove`を実行
 
 ## Commit Message Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,16 +13,18 @@
 
 ベースブランチ: `master`
 
-## Git ワークフロー
+## Git ワークフロー（必須）
 
-すべての変更は新しいブランチで作業し、Pull Requestで提出すること。
+**すべての変更はgit worktreeを使用し、Pull Requestで提出すること。**
 
-### 基本ルール
-- 常に新しいブランチで作業
-- 1ブランチ1修正の原則
-- すべての変更はPR経由
+### 主要コマンド
 
-### 詳細ルール
+```bash
+npm run worktree:new <type> <name>     # 新しいworktreeを作成
+npm run worktree:list                   # worktree一覧を表示
+npm run worktree:remove <type> <name>   # worktreeを削除
+```
+
 詳細なワークフローとベストプラクティスは `.claude/rules/workflow.md` を参照。
 
 ## プロジェクト概要

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",
     "playwright:install": "playwright install",
+    "worktree:new": "bash scripts/new-worktree.sh",
+    "worktree:remove": "bash scripts/remove-worktree.sh",
+    "worktree:list": "git worktree list",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# Git Worktree作成スクリプト
+# 使い方: ./scripts/new-worktree.sh <type> <name>
+# 例: ./scripts/new-worktree.sh feat new-feature
+
+set -e
+
+# 引数チェック
+if [ $# -ne 2 ]; then
+    echo "エラー: 引数が不足しています"
+    echo "使い方: npm run worktree:new <type> <name>"
+    echo ""
+    echo "利用可能なtype:"
+    echo "  feat      - 新機能"
+    echo "  fix       - バグ修正"
+    echo "  docs      - ドキュメント"
+    echo "  refactor  - リファクタリング"
+    echo "  test      - テスト追加"
+    echo "  chore     - ビルド・設定"
+    echo ""
+    echo "例: npm run worktree:new feat new-feature"
+    exit 1
+fi
+
+TYPE=$1
+NAME=$2
+BRANCH_NAME="${TYPE}/${NAME}"
+BASE_BRANCH="master"
+
+# 有効なtypeかチェック
+VALID_TYPES=("feat" "fix" "docs" "refactor" "test" "chore")
+if [[ ! " ${VALID_TYPES[@]} " =~ " ${TYPE} " ]]; then
+    echo "エラー: 無効なtype '${TYPE}'"
+    echo "利用可能なtype: ${VALID_TYPES[*]}"
+    exit 1
+fi
+
+# プロジェクトルートのディレクトリ名を取得
+PROJECT_DIR=$(basename "$(pwd)")
+
+# worktreeディレクトリ名を生成（親ディレクトリに作成）
+WORKTREE_DIR="../${PROJECT_DIR}-${TYPE}-${NAME}"
+
+echo "========================================="
+echo "Git Worktree作成"
+echo "========================================="
+echo "ブランチ名: ${BRANCH_NAME}"
+echo "Worktreeパス: ${WORKTREE_DIR}"
+echo "ベースブランチ: ${BASE_BRANCH}"
+echo "========================================="
+
+# ベースブランチの最新を取得
+echo ""
+echo "1. ベースブランチを更新..."
+git fetch origin "${BASE_BRANCH}"
+
+# worktreeディレクトリが既に存在するかチェック
+if [ -d "${WORKTREE_DIR}" ]; then
+    echo ""
+    echo "エラー: Worktreeディレクトリが既に存在します: ${WORKTREE_DIR}"
+    echo "既存のworktreeを削除する場合は: npm run worktree:remove ${TYPE} ${NAME}"
+    exit 1
+fi
+
+# ブランチが既に存在するかチェック
+if git rev-parse --verify "${BRANCH_NAME}" >/dev/null 2>&1; then
+    echo ""
+    echo "警告: ブランチ '${BRANCH_NAME}' は既に存在します"
+    read -p "既存のブランチを使用しますか? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "中止しました"
+        exit 1
+    fi
+    # 既存のブランチでworktreeを作成
+    git worktree add "${WORKTREE_DIR}" "${BRANCH_NAME}"
+else
+    # 新しいブランチを作成してworktreeを作成
+    echo ""
+    echo "2. 新しいブランチを作成してworktreeを追加..."
+    git worktree add -b "${BRANCH_NAME}" "${WORKTREE_DIR}" "origin/${BASE_BRANCH}"
+fi
+
+# 環境設定ファイルをコピー
+echo ""
+echo "3. 環境設定ファイルをコピー..."
+
+FILES_TO_COPY=(".env" ".env.local" ".mcp.json" ".claude/settings.local.json")
+
+for FILE in "${FILES_TO_COPY[@]}"; do
+    if [ -f "${FILE}" ]; then
+        # ディレクトリ構造を保持してコピー
+        FILE_DIR=$(dirname "${FILE}")
+        if [ "${FILE_DIR}" != "." ]; then
+            mkdir -p "${WORKTREE_DIR}/${FILE_DIR}"
+        fi
+        cp "${FILE}" "${WORKTREE_DIR}/${FILE}"
+        echo "  ✓ ${FILE} をコピーしました"
+    else
+        echo "  - ${FILE} は存在しません（スキップ）"
+    fi
+done
+
+# 依存関係をインストール
+echo ""
+echo "4. 依存関係をインストール..."
+cd "${WORKTREE_DIR}"
+npm install
+
+echo ""
+echo "========================================="
+echo "✓ Worktreeの作成が完了しました！"
+echo "========================================="
+echo ""
+echo "Worktreeディレクトリに移動して作業を開始してください:"
+echo ""
+echo "  cd ${WORKTREE_DIR}"
+echo ""
+echo "開発サーバーの起動:"
+echo "  npm run dev"
+echo ""
+echo "作業完了後、worktreeを削除:"
+echo "  cd ../${PROJECT_DIR}"
+echo "  npm run worktree:remove ${TYPE} ${NAME}"
+echo ""

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Git Worktree削除スクリプト
+# 使い方: ./scripts/remove-worktree.sh <type> <name>
+# 例: ./scripts/remove-worktree.sh feat new-feature
+
+set -e
+
+# 引数チェック
+if [ $# -ne 2 ]; then
+    echo "エラー: 引数が不足しています"
+    echo "使い方: npm run worktree:remove <type> <name>"
+    echo ""
+    echo "例: npm run worktree:remove feat new-feature"
+    exit 1
+fi
+
+TYPE=$1
+NAME=$2
+BRANCH_NAME="${TYPE}/${NAME}"
+
+# プロジェクトルートのディレクトリ名を取得
+PROJECT_DIR=$(basename "$(pwd)")
+
+# worktreeディレクトリ名を生成
+WORKTREE_DIR="../${PROJECT_DIR}-${TYPE}-${NAME}"
+
+echo "========================================="
+echo "Git Worktree削除"
+echo "========================================="
+echo "ブランチ名: ${BRANCH_NAME}"
+echo "Worktreeパス: ${WORKTREE_DIR}"
+echo "========================================="
+
+# worktreeが存在するかチェック
+if ! git worktree list | grep -q "${WORKTREE_DIR}"; then
+    echo ""
+    echo "エラー: Worktreeが見つかりません: ${WORKTREE_DIR}"
+    echo ""
+    echo "現在のworktree一覧:"
+    git worktree list
+    exit 1
+fi
+
+# 確認プロンプト
+echo ""
+read -p "このworktreeを削除してもよろしいですか? (y/N): " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "中止しました"
+    exit 1
+fi
+
+# worktreeを削除
+echo ""
+echo "1. Worktreeを削除..."
+git worktree remove "${WORKTREE_DIR}" --force
+
+echo ""
+echo "========================================="
+echo "✓ Worktreeの削除が完了しました"
+echo "========================================="
+echo ""
+echo "ブランチ '${BRANCH_NAME}' は残っています。"
+echo ""
+echo "ブランチも削除する場合:"
+echo "  git branch -D ${BRANCH_NAME}"
+echo ""
+echo "リモートからもブランチを削除する場合:"
+echo "  git push origin --delete ${BRANCH_NAME}"
+echo ""


### PR DESCRIPTION
## 概要

複数ブランチの並行作業を可能にするため、git worktreeを使った新しいワークフローを導入しました。

## 主な変更

### 新規追加

#### `scripts/new-worktree.sh`
- 新しいworktreeを自動作成
- ブランチ命名規則のバリデーション（feat, fix, docs, refactor, test, chore）
- 環境設定ファイルの自動コピー:
  - `.env` / `.env.local`
  - `.mcp.json`（MCP設定）
  - `.claude/settings.local.json`（Claude Code設定）
- `npm install`の自動実行

#### `scripts/remove-worktree.sh`
- worktreeの安全な削除（確認プロンプト付き）
- ブランチ削除のガイド表示

#### `package.json`
worktree管理用のnpm scriptsを追加:
- `worktree:new <type> <name>` - 新しいworktreeを作成
- `worktree:remove <type> <name>` - worktreeを削除
- `worktree:list` - worktree一覧を表示

### 更新

#### `CLAUDE.md`
- Git Worktreeワークフローのセクションを追加
- 主要コマンドのクイックリファレンスを記載

#### `.claude/rules/workflow.md`
- 従来のワークフロー例をworktreeベースに書き換え
- 複数ブランチ並行作業の例を追加
- 環境設定ファイルの自動コピーについて記載

## 使い方

```bash
# 新しい機能を開発
npm run worktree:new feat new-feature  # 環境ファイルコピー + npm install自動実行
cd ../schedule-app-feat-new-feature
npm run dev

# 作業完了後
cd ../schedule-app
npm run worktree:remove feat new-feature
```

## メリット

- ✅ 複数ブランチを同時に作業可能
- ✅ メインworktreeの開発サーバーを起動したまま別作業できる
- ✅ 環境設定ファイル（MCP、Claude設定など）が自動的に引き継がれる
- ✅ `npm install`を手動実行する必要がない
- ✅ ブランチ切り替えでuntracked filesを気にする必要がない

## テスト計画

- [x] `new-worktree.sh`の動作確認（worktree作成、ファイルコピー、npm install）
- [x] `remove-worktree.sh`の動作確認（worktree削除）
- [x] スクリプトの構文チェック
- [ ] 実際の開発フローでの運用テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)