### PR TITLE
worktreeコマンド構文修正とタスク引継ぎ機能を追加

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -71,7 +71,7 @@ Worktreeパス: /path/to/schedule-app-feat-new-feature
 tmux
 
 # worktreeを作成（タスク説明を指定）
-npm run worktree:new feat new-feature --task "新機能の説明"
+npm run worktree:new -- feat new-feature --task "新機能の説明"
 
 # 自動で以下が実行されます：
 # 1. 新しいworktreeを作成
@@ -89,7 +89,7 @@ npm run worktree:new feat new-feature --task "新機能の説明"
 
 ```bash
 # tmux外で実行
-npm run worktree:new feat new-feature
+npm run worktree:new -- feat new-feature
 
 # worktreeのみ作成される（警告メッセージを表示）
 # 手動でworktreeディレクトリに移動してClaudeを起動
@@ -106,7 +106,7 @@ claude
 tmux
 
 # 1. worktreeを作成（タスク説明付き）
-npm run worktree:new feat new-feature --task "新しいUI要素を追加"
+npm run worktree:new -- feat new-feature --task "新しいUI要素を追加"
 
 # 2. 自動で以下が実行されます：
 #    - worktree作成、依存関係インストール
@@ -132,7 +132,7 @@ gh pr create --title "..." --body "..."
 
 ```bash
 # タスク説明を指定しない場合
-npm run worktree:new fix bug-fix
+npm run worktree:new -- fix bug-fix
 
 # コンテキストファイルに「タスク説明はありません」と表示されます
 ```
@@ -149,7 +149,7 @@ npm run worktree:new fix bug-fix
 cd ../schedule-app
 
 # 2つ目のworktreeを作成（別のpaneが自動作成される）
-npm run worktree:new fix urgent-bug --task "緊急バグ修正"
+npm run worktree:new -- fix urgent-bug --task "緊急バグ修正"
 
 # 左右のpaneを切り替えて、複数タスクを並行作業可能
 # tmux pane切り替え: Ctrl-b + 方向キー（または Ctrl-b + o）
@@ -166,7 +166,7 @@ npm run dev  # ポート5173で起動
 
 # 別ターミナルで緊急バグ修正（依存関係も自動インストール）
 cd ../schedule-app
-npm run worktree:new fix urgent-bug
+npm run worktree:new -- fix urgent-bug
 cd ../schedule-app-fix-urgent-bug
 # 修正してコミット
 
@@ -188,7 +188,7 @@ worktreeが不要になった場合は削除できます：
 ```bash
 # メインプロジェクトから実行
 cd ../schedule-app
-npm run worktree:remove feat new-feature
+npm run worktree:remove -- feat new-feature
 ```
 
 **Note**: マージ済みブランチのworktreeは、`npm run worktree:cleanup`で一括削除できます。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,12 @@
 
 ```bash
 # tmux統合機能付き（推奨）
-npm run worktree:new <type> <name> --task "タスク説明"  # worktree作成、pane分割、Claude起動
+npm run worktree:new -- <type> <name> --task "タスク説明"  # worktree作成、pane分割、Claude起動
 
 # シンプル版
-npm run worktree:new <type> <name>     # worktree作成のみ
-npm run worktree:list                   # worktree一覧を表示
-npm run worktree:remove <type> <name>   # worktreeを削除
+npm run worktree:new -- <type> <name>     # worktree作成のみ
+npm run worktree:list                      # worktree一覧を表示
+npm run worktree:remove -- <type> <name>   # worktreeを削除
 ```
 
 #### tmux統合機能について
@@ -40,7 +40,7 @@ npm run worktree:remove <type> <name>   # worktreeを削除
 ```bash
 # tmuxセッション内で実行
 tmux
-npm run worktree:new feat my-feature --task "新しいUI要素を追加"
+npm run worktree:new -- feat my-feature --task "新しいUI要素を追加"
 ```
 
 詳細は `.claude/rules/workflow.md` の「tmux統合機能」セクションを参照。

--- a/scripts/launch-claude-with-context.sh
+++ b/scripts/launch-claude-with-context.sh
@@ -1,8 +1,39 @@
 #!/bin/bash
-# Claudeをコンテキスト付きで起動
+# Claudeをコンテキスト付きで起動し、タスク内容から初期コマンドを自動実行
 
 CONTEXT_FILE=".claude/worktree-context.md"
 
+# タスク説明を抽出して初期コマンドを判定
+determine_initial_command() {
+    if [ ! -f "$CONTEXT_FILE" ]; then
+        echo ""
+        return
+    fi
+
+    # ユーザーからの指示セクションを抽出
+    local task_section=$(sed -n '/## ユーザーからの指示/,/## /p' "$CONTEXT_FILE" | head -n -1)
+
+    # キーワード検出して初期コマンドを決定
+    if echo "$task_section" | grep -qiE "テスト|TDD|実装|機能|修正|バグ|コード書|実装し"; then
+        # デフォルト: TDD（テスト駆動開発）
+        echo "/tdd"
+    elif echo "$task_section" | grep -qiE "リファクタ|クリーンアップ|最適化|設計"; then
+        # 設計系は計画確認
+        echo "/plan"
+    elif echo "$task_section" | grep -qiE "ドキュメント|doc|README|ログ"; then
+        # ドキュメントはそのまま編集
+        echo ""
+    else
+        # デフォルト: TDD
+        echo "/tdd"
+    fi
+}
+
+# 初期コマンドを取得して環境変数に設定
+INITIAL_COMMAND=$(determine_initial_command)
+export CLAUDE_INITIAL_COMMAND="$INITIAL_COMMAND"
+
+# コンテキストファイルの内容を表示
 if [ -f "$CONTEXT_FILE" ]; then
     echo "========================================="
     echo " Worktree タスクコンテキスト"
@@ -11,10 +42,29 @@ if [ -f "$CONTEXT_FILE" ]; then
     cat "$CONTEXT_FILE"
     echo ""
     echo "========================================="
+    if [ -n "$INITIAL_COMMAND" ]; then
+        echo " 推奨コマンド: $INITIAL_COMMAND"
+    fi
     echo " Claudeを起動します..."
     echo "========================================="
     echo ""
 fi
 
-# Claudeを起動
-claude
+# Claudeを起動（バックグラウンド）
+claude &
+CLAUDE_PID=$!
+
+# Claudeの起動と初期化を待つ
+sleep 1
+
+# 初期コマンドがあり、tmux pane内の場合は自動送信
+if [ -n "$INITIAL_COMMAND" ] && [ -n "$TMUX" ]; then
+    CURRENT_PANE=$(tmux display-message -p "#{pane_id}")
+    if [ -n "$CURRENT_PANE" ]; then
+        sleep 1  # Claudeの完全な初期化を待つ
+        tmux send-keys -t "$CURRENT_PANE" "$INITIAL_COMMAND" C-m
+    fi
+fi
+
+# Claudeプロセスを待機
+wait $CLAUDE_PID


### PR DESCRIPTION
## Summary
- `npm run worktree:new`コマンドの構文を修正（`--`を追加）
- Claude起動時にタスク内容から初期コマンドを自動判定して実行
- worktree間でタスクコンテキストを引き継ぐ機能を実装

## Details

### 構文修正
ドキュメント内の`npm run worktree:new`コマンドの呼び出し方法を統一し、`--`を追加して正しい構文に修正しました。

### タスク引継ぎ機能
`launch-claude-with-context.sh`スクリプトに以下を追加：
- タスク説明からキーワードを抽出して推奨コマンドを判定
- tmux pane内で自動的に初期コマンドを実行
- `/tdd`、`/plan`などをタスク内容に応じて自動選択

これにより、worktree作成時にタスク内容を指定すると、新しいClaudeセッションで自動的に適切なワークフローが開始されます。

## Test plan
- [ ] `npm run worktree:new -- feat test --task "新機能を実装"`を実行
- [ ] 新しいpaneでClaudeが起動し、`/tdd`コマンドが自動実行されることを確認
- [ ] ドキュメントのコマンド例がすべて正しい構文になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)