### PR TITLE
予定リストに日付ラベル（YYYY/MM/DD形式）を追加

### DIFF
--- a/src/components/ScheduleList.css
+++ b/src/components/ScheduleList.css
@@ -10,6 +10,13 @@
   min-height: 0;
 }
 
+.schedule-list-date {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 12px;
+}
+
 .no-schedules {
   color: #6b7280;
   text-align: center;

--- a/src/components/ScheduleList.tsx
+++ b/src/components/ScheduleList.tsx
@@ -1,4 +1,5 @@
 import type { Schedule } from '../types/schedule';
+import { formatDateLabel } from '../utils/date';
 import { hasMoreThanLines } from '../utils/textUtils';
 import './ScheduleList.css';
 
@@ -17,6 +18,7 @@ export function ScheduleList({ schedules, selectedDate, onEdit, onDelete }: Sche
 
   return (
     <div className="schedule-list">
+      <div className="schedule-list-date">{formatDateLabel(selectedDate)}</div>
       {filteredSchedules.length === 0 ? (
         <p className="no-schedules">予定がありません</p>
       ) : (

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -88,3 +88,12 @@ export function getMonthName(year: number, month: number): string {
     month: 'long',
   });
 }
+
+/**
+ * YYYY-MM-DD形式の文字列をYYYY/MM/DD形式に変換
+ * @param dateStr YYYY-MM-DD形式の日付文字列
+ * @returns YYYY/MM/DD形式の日付文字列
+ */
+export function formatDateLabel(dateStr: string): string {
+  return dateStr.replace(/-/g, '/');
+}

--- a/tests/components/ScheduleList.test.tsx
+++ b/tests/components/ScheduleList.test.tsx
@@ -155,4 +155,53 @@ describe('ScheduleList', () => {
       expect(descriptions).toHaveLength(1);
     });
   });
+
+  describe('日付ラベル', () => {
+    it('リストの左上にYYYY/MM/DD形式で日付が表示される', () => {
+      const schedules = [createSchedule()];
+
+      render(
+        <ScheduleList
+          schedules={schedules}
+          selectedDate="2024-01-01"
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const dateLabel = screen.getByText('2024/01/01');
+      expect(dateLabel).toBeInTheDocument();
+      expect(dateLabel).toHaveClass('schedule-list-date');
+    });
+
+    it('異なる日付でも正しく表示される', () => {
+      const schedules = [createSchedule({ date: '2024-12-31' })];
+
+      render(
+        <ScheduleList
+          schedules={schedules}
+          selectedDate="2024-12-31"
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const dateLabel = screen.getByText('2024/12/31');
+      expect(dateLabel).toBeInTheDocument();
+    });
+
+    it('予定がない場合でも日付ラベルは表示される', () => {
+      render(
+        <ScheduleList
+          schedules={[]}
+          selectedDate="2024-06-15"
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const dateLabel = screen.getByText('2024/06/15');
+      expect(dateLabel).toBeInTheDocument();
+    });
+  });
 });

--- a/tests/utils/date.test.ts
+++ b/tests/utils/date.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   formatDate,
+  formatDateLabel,
   formatDisplayDate,
   getMonthDays,
   getMonthName,
@@ -118,5 +119,19 @@ describe('getMonthName', () => {
     const result = getMonthName(2024, 11); // 2024年12月
     expect(result).toContain('2024');
     expect(result).toContain('12');
+  });
+});
+
+describe('formatDateLabel', () => {
+  it('YYYY-MM-DD形式の文字列をYYYY/MM/DD形式に変換する', () => {
+    expect(formatDateLabel('2024-01-01')).toBe('2024/01/01');
+  });
+
+  it('月と日の0埋めを保持する', () => {
+    expect(formatDateLabel('2024-05-09')).toBe('2024/05/09');
+  });
+
+  it('12月31日を正しく変換する', () => {
+    expect(formatDateLabel('2024-12-31')).toBe('2024/12/31');
   });
 });


### PR DESCRIPTION
## Summary
- 予定詳細リストの左上にYYYY/MM/DD形式の日付ラベルを表示
- `formatDateLabel`ユーティリティ関数を追加してYYYY-MM-DD形式をYYYY/MM/DD形式に変換
- 既存のレイアウトを保持しつつ、日付情報を明確に表示

## Details
### 実装内容
- **新規関数**: `src/utils/date.ts`に`formatDateLabel`関数を追加
- **コンポーネント**: `ScheduleList`コンポーネントに日付ラベル（`.schedule-list-date`）を追加
- **スタイル**: 既存のデザインに馴染むスタイルを適用（font-size: 0.875rem, font-weight: 600）

### テスト
- `formatDateLabel`関数のユニットテストを追加（3ケース）
- `ScheduleList`コンポーネントの日付ラベル表示テストを追加（3ケース）
- テストカバレッジ: 94.44%（目標80%以上を達成）

### Safari/iOS互換性
- 標準的なHTML、CSS、JavaScriptのみ使用
- `String.replace()`はSafari対応済み

## Test plan
- [x] ユニットテストが全て成功することを確認
- [x] ビルドが成功することを確認
- [x] テストカバレッジが80%以上であることを確認
- [ ] 開発サーバーで日付ラベルが正しく表示されることを確認
- [ ] 異なる日付を選択して日付ラベルが更新されることを確認
- [ ] Safari/iPhoneで表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)